### PR TITLE
Remove multiple databases from database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,21 +21,9 @@ default: &default
 
 
 development:
-  primary: &primary_development
-    <<: *default
-    database: shinar_development
-  cache:
-    <<: *primary_development
-    database: shinar_development_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_development
-    database: shinar_development_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_development
-    database: shinar_development_cable
-    migrations_paths: db/cable_migrate
+  <<: *default
+  database: shinar_development
+
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.


### PR DESCRIPTION
I tested by switching 

```rb
  after_create_commit -> { broadcast_refresh_to chat }
  after_update_commit -> { broadcast_refresh_to chat }
  after_destroy_commit -> { broadcast_refresh_to chat }
```

to 

```rb
  after_create_commit -> { broadcast_refresh_later_to chat }
  after_update_commit -> { broadcast_refresh_later_to chat }
  after_destroy_commit -> { broadcast_refresh_later_to chat }
```

and ran `bin/jobs` in another terminal and the broadcasts happened as expected

![shinar-broadcast-refresh-later](https://github.com/user-attachments/assets/2381167e-b700-4187-89cd-8b3e1bb9b8e5)
